### PR TITLE
Fix text processing mistake when `trigger.group(2)` isn't set

### DIFF
--- a/sopel_rainbow/__init__.py
+++ b/sopel_rainbow/__init__.py
@@ -50,9 +50,9 @@ def setup(bot):
 @module.commands('rainbow')
 def rainbow_cmd(bot, trigger):
     """Make text into a rainbow."""
-    text = clean(trigger.group(2))
+    text = clean(trigger.group(2) or '').strip()
 
-    if text == None:
+    if not text:
         bot.reply("I can't make a rainbow out of nothing!")
         return module.NOLIMIT
 


### PR DESCRIPTION
This bug won't affect Sopel 7.0, only 7.1+ (after `formatting.plain()` exists), but best fix it now before 7.1 actually comes out.